### PR TITLE
fix node install

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -10,8 +10,8 @@ set -x
 
 # Install foundry
 echo "===== 1. INSTALLING DEPENDENCIES ====="
-sudo dnf install https://rpm.nodesource.com/pub_20.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
-sudo dnf install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
+curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
+dnf install -y nodejs
 sudo dnf install -y openssl-devel
 sudo dnf install -y amazon-cloudwatch-agent
 


### PR DESCRIPTION
To resolve the following error

> Node.js Packages for Linux RPM based distros -  1.6 MB/s | 1.7 kB     00:00
> Importing GPG key 0x9B1BE0B4:
>  Userid     : "NSolid <nsolid-gpg@nodesource.com>"
>  Fingerprint: 6F71 F525 2828 41EE DAF8 51B4 2F59 B5F9 9B1B E0B4
>  From       : /etc/pki/rpm-gpg/NODESOURCE-NSOLID-GPG-SIGNING-KEY-EL
> Key imported successfully
> Import of key(s) didn't help, wrong key(s)?
> Public key for nodejs-20.11.1-1nodesource.aarch64.rpm is not installed. Failing package is: nodejs-2:20.11.1-1nodesource.aarch64
>  GPG Keys are configured as: file:///etc/pki/rpm-gpg/NODESOURCE-NSOLID-GPG-SIGNING-KEY-EL
> The downloaded packages were saved in cache until the next successful transaction.
> You can remove cached packages by executing 'dnf clean packages'.
> Error: GPG check FAILED

Solution sourced here:
https://github.com/nodesource/distributions/issues/1747#issuecomment-1878708551